### PR TITLE
Allow delete to have body

### DIFF
--- a/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
@@ -22,8 +22,9 @@ import java.util.Map;
 
 public final class CallableRequest extends TypedRequest {
   private CallableRequest(Retrofit retrofit, ParameterizedType returnType,
-      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody, Object tag,
-      List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
+      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody,
+      Object tag, List<Query> query, Map<String, String> headers, List<Part> parts,
+      List<Field> fields) {
     super(retrofit, returnType, bodyEncoding, path,
         method, body, hasBody, tag, query, headers, parts, fields);
   }
@@ -56,8 +57,8 @@ public final class CallableRequest extends TypedRequest {
           return null;
         }
       };
-      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag, query,
-          headers, parts, fields);
+      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag,
+          query, headers, parts, fields);
     }
 
     @Override public Builder path(String path) {

--- a/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
@@ -22,10 +22,10 @@ import java.util.Map;
 
 public final class CallableRequest extends TypedRequest {
   private CallableRequest(Retrofit retrofit, ParameterizedType returnType,
-      BodyEncoding bodyEncoding, String path, Method method, Object body, Object tag,
+      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody, Object tag,
       List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
     super(retrofit, returnType, bodyEncoding, path,
-        method, body, tag, query, headers, parts, fields);
+        method, body, hasBody, tag, query, headers, parts, fields);
   }
 
   public Builder newBuilder(Retrofit retrofit) {
@@ -56,7 +56,7 @@ public final class CallableRequest extends TypedRequest {
           return null;
         }
       };
-      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, tag, query,
+      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag, query,
           headers, parts, fields);
     }
 

--- a/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/CallableRequest.java
@@ -57,8 +57,8 @@ public final class CallableRequest extends TypedRequest {
           return null;
         }
       };
-      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag,
-          query, headers, parts, fields);
+      return new CallableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody,
+          tag, query, headers, parts, fields);
     }
 
     @Override public Builder path(String path) {

--- a/retrofit-typedrequest/src/main/java/retrofit2/ObservableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/ObservableRequest.java
@@ -24,10 +24,10 @@ import io.reactivex.Observable;
 
 public final class ObservableRequest extends TypedRequest {
   ObservableRequest(Retrofit retrofit, ParameterizedType returnType, BodyEncoding bodyEncoding,
-      String path, Method method, Object body, Object tag, List<Query> query,
+      String path, Method method, Object body, boolean hasBody, Object tag, List<Query> query,
       Map<String, String> headers, List<Part> parts, List<Field> fields) {
     super(retrofit, returnType, bodyEncoding,
-        path, method, body, tag, query, headers, parts, fields);
+        path, method, body, hasBody, tag, query, headers, parts, fields);
   }
 
   public Builder newBuilder(Retrofit retrofit) {
@@ -58,7 +58,7 @@ public final class ObservableRequest extends TypedRequest {
           return null;
         }
       };
-      return new ObservableRequest(retrofit, returnType, bodyEncoding, path, method, body, tag,
+      return new ObservableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag,
           query, headers, parts, fields);
     }
 

--- a/retrofit-typedrequest/src/main/java/retrofit2/ObservableRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/ObservableRequest.java
@@ -58,8 +58,8 @@ public final class ObservableRequest extends TypedRequest {
           return null;
         }
       };
-      return new ObservableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody, tag,
-          query, headers, parts, fields);
+      return new ObservableRequest(retrofit, returnType, bodyEncoding, path, method, body, hasBody,
+          tag, query, headers, parts, fields);
     }
 
     @Override public Builder path(String path) {

--- a/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
@@ -214,8 +214,8 @@ public abstract class TypedRequest {
       return this;
     }
 
-    private Builder requestHasBody(boolean requestHasBody) {
-      this.hasBody = requestHasBody;
+    private Builder hasBody(boolean hasBody) {
+      this.hasBody = hasBody;
       return this;
     }
 
@@ -236,7 +236,7 @@ public abstract class TypedRequest {
       boolean isStandardBodyRequest = method == Method.PATCH || method == Method.POST
           || method == Method.PUT;
       boolean isDeleteWithBody = method == Method.DELETE && gotBody;
-      this.requestHasBody(isStandardBodyRequest || isDeleteWithBody);
+      this.hasBody(isStandardBodyRequest || isDeleteWithBody);
 
       boolean gotField = !fields.isEmpty();
       boolean gotPart = !parts.isEmpty();

--- a/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
@@ -47,8 +47,9 @@ public abstract class TypedRequest {
   protected boolean hasBody;
 
   TypedRequest(Retrofit retrofit, ParameterizedType returnType,
-      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody, Object tag,
-      List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
+      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody,
+      Object tag, List<Query> query, Map<String, String> headers, List<Part> parts,
+      List<Field> fields) {
     this.returnType = returnType;
     this.path = path;
     this.method = method;
@@ -228,9 +229,12 @@ public abstract class TypedRequest {
       }
 
       boolean gotBody = body != null;
-      // Retrofit typically supports delete with body via @Http annotation. TypedRequest cannot support that easily, so to match
-      // expected retrofit behavior, DELETE requests are normally _not_ sent with a body. If a body is present, however, we allow it.
-      boolean isStandardBodyRequest = method == Method.PATCH || method == Method.POST || method == Method.PUT;
+      // Retrofit typically supports delete with body via @Http annotation.
+      // TypedRequest cannot support that easily, so to match
+      // expected retrofit behavior, DELETE requests are normally _not_ sent with a body.
+      // If a body is present, however, we allow it.
+      boolean isStandardBodyRequest = method == Method.PATCH || method == Method.POST
+          || method == Method.PUT;
       boolean isDeleteWithBody = method == Method.DELETE && gotBody;
       this.requestHasBody(isStandardBodyRequest || isDeleteWithBody);
 

--- a/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/TypedRequest.java
@@ -44,14 +44,16 @@ public abstract class TypedRequest {
   protected final CallAdapter callAdapter;
   protected final TypedRawCallFactory<Object> callFactory;
   protected boolean isCancelled;
+  protected boolean hasBody;
 
   TypedRequest(Retrofit retrofit, ParameterizedType returnType,
-      BodyEncoding bodyEncoding, String path, Method method, Object body, Object tag,
+      BodyEncoding bodyEncoding, String path, Method method, Object body, boolean hasBody, Object tag,
       List<Query> query, Map<String, String> headers, List<Part> parts, List<Field> fields) {
     this.returnType = returnType;
     this.path = path;
     this.method = method;
     this.body = body;
+    this.hasBody = hasBody;
     this.tag = tag;
     this.query = query;
     this.headers = headers;
@@ -134,6 +136,7 @@ public abstract class TypedRequest {
     protected Map<String, String> headers = Collections.emptyMap();
     protected List<Part> parts = Collections.emptyList();
     protected List<Field> fields = Collections.emptyList();
+    protected boolean hasBody;
 
     public Builder(Retrofit retrofit, TypedRequest request) {
       this(retrofit);
@@ -210,6 +213,11 @@ public abstract class TypedRequest {
       return this;
     }
 
+    private Builder requestHasBody(boolean requestHasBody) {
+      this.hasBody = requestHasBody;
+      return this;
+    }
+
     public TypedRequest build() {
       checkNotNull(path, "path == null");
       checkNotNull(method, "method == null");
@@ -219,14 +227,17 @@ public abstract class TypedRequest {
         throw new IllegalArgumentException("URL path \"" + path + "\" must start with '/'.");
       }
 
-      boolean requestHasBody =
-          method == Method.PATCH || method == Method.POST || method == Method.PUT;
-
       boolean gotBody = body != null;
+      // Retrofit typically supports delete with body via @Http annotation. TypedRequest cannot support that easily, so to match
+      // expected retrofit behavior, DELETE requests are normally _not_ sent with a body. If a body is present, however, we allow it.
+      boolean isStandardBodyRequest = method == Method.PATCH || method == Method.POST || method == Method.PUT;
+      boolean isDeleteWithBody = method == Method.DELETE && gotBody;
+      this.requestHasBody(isStandardBodyRequest || isDeleteWithBody);
+
       boolean gotField = !fields.isEmpty();
       boolean gotPart = !parts.isEmpty();
 
-      if (bodyEncoding == BodyEncoding.NONE && !requestHasBody && gotBody) {
+      if (bodyEncoding == BodyEncoding.NONE && !hasBody && gotBody) {
         throw new IllegalArgumentException("Non-body HTTP method cannot contain body.");
       }
       if (bodyEncoding == BodyEncoding.FORM_URL_ENCODED && !gotField) {

--- a/retrofit-typedrequest/src/main/java/retrofit2/TypedRequestRawRequestBuilder.java
+++ b/retrofit-typedrequest/src/main/java/retrofit2/TypedRequestRawRequestBuilder.java
@@ -53,8 +53,7 @@ public final class TypedRequestRawRequestBuilder {
     this.urlBuilder = retrofit.baseUrl().newBuilder();
     this.request = request;
     this.requestMethod = request.method().name();
-    this.hasBody = "PATCH".equals(requestMethod) || "POST".equals(requestMethod)
-        || "PUT".equals(requestMethod);
+    this.hasBody = request.hasBody;
 
     if (request.bodyEncoding() == TypedRequest.BodyEncoding.FORM_URL_ENCODED) {
       // Will be set to 'body' in 'build'.

--- a/retrofit-typedrequest/src/test/java/retrofit2/TypedRequestRawRequestBuilderTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit2/TypedRequestRawRequestBuilderTest.java
@@ -73,7 +73,7 @@ public class TypedRequestRawRequestBuilderTest {
     assertThat(request.method()).isEqualTo("DELETE");
     assertThat(request.headers().size()).isZero();
     assertThat(request.url().toString()).isEqualTo(server.url("/foo/bar/").toString());
-    assertThat(request.body()).isEqualTo("hi");
+    assertBody(request.body(), "hi");
   }
 
   @Test public void head() {

--- a/retrofit-typedrequest/src/test/java/retrofit2/TypedRequestRawRequestBuilderTest.java
+++ b/retrofit-typedrequest/src/test/java/retrofit2/TypedRequestRawRequestBuilderTest.java
@@ -67,6 +67,15 @@ public class TypedRequestRawRequestBuilderTest {
     assertThat(request.body()).isNull();
   }
 
+  @Test public void deleteWithBody() {
+    RequestBody body = RequestBody.create(MediaType.parse("text/plain"), "hi");
+    okhttp3.Request request = buildRequest(Method.DELETE, body);
+    assertThat(request.method()).isEqualTo("DELETE");
+    assertThat(request.headers().size()).isZero();
+    assertThat(request.url().toString()).isEqualTo(server.url("/foo/bar/").toString());
+    assertThat(request.body()).isEqualTo("hi");
+  }
+
   @Test public void head() {
     okhttp3.Request request = buildRequest(Method.HEAD);
     assertThat(request.method()).isEqualTo("HEAD");


### PR DESCRIPTION
Currently TypeRequest (a concept only in this fork) does not allow bodies in delete requests. The main retrofit library, which uses annotations, has a `@Http(method, hasBody)` annotation which can be used to escape the default delete with no body issue.

I did not want to blanket add support for `delete` with body as that would change delete requests without a body to start sending an empty object instead of null. So this only sends the delete body, if one is present.

@rossbacher @elihart 